### PR TITLE
refactor: DRY quicktree action form wrappers

### DIFF
--- a/quicktree.php
+++ b/quicktree.php
@@ -27,6 +27,7 @@ $guest_account = true;
 
 chdir('../../');
 include_once('include/auth.php');
+include_once('plugins/quicktree/ui_helpers.php');
 
 define('QUICKTREE_BASE_URI', $config['url_path'] . 'plugins/quicktree/');
 
@@ -99,13 +100,7 @@ switch ($action) {
 
 		break;
 	case 'add_tree':
-		if (get_nfilter_request_var('header') == null) {
-			top_header();
-		}
-
-		form_start('quicktree.php', 'quicktree_form');
-
-		html_start_box($form_actions[$drp_action], '60%', '', '3', 'center', '');
+		quicktree_action_form_begin($form_actions[$drp_action]);
 
 		print '<tr><td>';
 
@@ -138,19 +133,11 @@ switch ($action) {
 			<input type="button" value="' . __esc('Cancel') . '" onClick="cactiReturnTo()">&nbsp;<input type="submit" value="' . __esc('Continue') . '" title="' . __esc('Add To Branch', 'quicktree') . '">
 		</td></tr>';
 
-		html_end_box();
-
-		form_end();
+		quicktree_action_form_end();
 
 		break;
 	case 'add_branch':
-		if (get_nfilter_request_var('header') == null) {
-			top_header();
-		}
-
-		form_start('quicktree.php', 'quicktree_form');
-
-		html_start_box($form_actions[$drp_action], '60%', '', '3', 'center', '');
+		quicktree_action_form_begin($form_actions[$drp_action]);
 
 		$queryrows = db_fetch_assoc("SELECT g.id, g.name
 			FROM graph_tree AS g
@@ -197,9 +184,7 @@ switch ($action) {
 			<input type="button" value="' . __esc('Cancel') . '" onClick="cactiReturnTo()"><input type="submit" value="' . __esc('Continue') . '" title="' . __esc('Add To Branch', 'quicktree') . '">
 		</td></tr>';
 
-		html_end_box();
-
-		form_end();
+		quicktree_action_form_end();
 
 		break;
 	case 'clear':
@@ -430,4 +415,3 @@ switch ($action) {
 
 		break;
 }
-

--- a/tests/test_form_wrapper.php
+++ b/tests/test_form_wrapper.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2010-2022 Howard Jones                                    |
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for shared quicktree action-form wrappers             |
+ |                                                                         |
+ | Run: php tests/test_form_wrapper.php                                    |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+$events = array();
+$request_vars = array();
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+function get_nfilter_request_var($name) {
+	global $request_vars;
+
+	return array_key_exists($name, $request_vars) ? $request_vars[$name] : null;
+}
+
+function top_header() {
+	global $events;
+	$events[] = 'top_header';
+}
+
+function form_start($action, $form) {
+	global $events;
+	$events[] = "form_start:$action:$form";
+}
+
+function html_start_box($title) {
+	global $events;
+	$events[] = "html_start_box:$title";
+}
+
+function html_end_box() {
+	global $events;
+	$events[] = 'html_end_box';
+}
+
+function form_end() {
+	global $events;
+	$events[] = 'form_end';
+}
+
+require_once __DIR__ . '/../ui_helpers.php';
+
+$events = array();
+$request_vars = array('header' => null);
+quicktree_action_form_begin('Tree Action');
+quicktree_action_form_end();
+
+assert_true(
+	'begin/end wrapper includes top header when header var is null',
+	$events === array('top_header', 'form_start:quicktree.php:quicktree_form', 'html_start_box:Tree Action', 'html_end_box', 'form_end')
+);
+
+$events = array();
+$request_vars = array('header' => 'false');
+quicktree_action_form_begin('Branch Action');
+quicktree_action_form_end();
+
+assert_true(
+	'begin/end wrapper omits top header when header var is set',
+	$events === array('form_start:quicktree.php:quicktree_form', 'html_start_box:Branch Action', 'html_end_box', 'form_end')
+);
+
+$source = file_get_contents(__DIR__ . '/../quicktree.php');
+
+assert_true(
+	'quicktree.php includes ui helper file',
+	strpos($source, "include_once('plugins/quicktree/ui_helpers.php');") !== false
+);
+assert_true(
+	'quicktree.php uses begin wrapper in add-tree and add-branch',
+	substr_count($source, 'quicktree_action_form_begin(') >= 2
+);
+assert_true(
+	'quicktree.php uses end wrapper in add-tree and add-branch',
+	substr_count($source, 'quicktree_action_form_end();') >= 2
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/tests/test_form_wrapper.php
+++ b/tests/test_form_wrapper.php
@@ -81,18 +81,20 @@ assert_true(
 );
 
 $source = file_get_contents(__DIR__ . '/../quicktree.php');
+assert_true('quicktree.php is readable', $source !== false);
+$source = ($source === false ? '' : $source);
 
 assert_true(
 	'quicktree.php includes ui helper file',
-	strpos($source, "include_once('plugins/quicktree/ui_helpers.php');") !== false
+	preg_match('/(?:include_once|require_once)\s*\(\s*[\'"]plugins\/quicktree\/ui_helpers\.php[\'"]\s*\)\s*;/', $source) === 1
 );
 assert_true(
 	'quicktree.php uses begin wrapper in add-tree and add-branch',
-	substr_count($source, 'quicktree_action_form_begin(') >= 2
+	preg_match_all('/quicktree_action_form_begin\s*\(/', $source, $begin_matches) >= 2
 );
 assert_true(
 	'quicktree.php uses end wrapper in add-tree and add-branch',
-	substr_count($source, 'quicktree_action_form_end();') >= 2
+	preg_match_all('/quicktree_action_form_end\s*\(\s*\)\s*;/', $source, $end_matches) >= 2
 );
 
 echo "\n";

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2010-2022 Howard Jones                                    |
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('quicktree_action_form_begin')) {
+	function quicktree_action_form_begin($title) {
+		if (get_nfilter_request_var('header') == null) {
+			top_header();
+		}
+
+		form_start('quicktree.php', 'quicktree_form');
+		html_start_box($title, '60%', '', '3', 'center', '');
+	}
+}
+
+if (!function_exists('quicktree_action_form_end')) {
+	function quicktree_action_form_end() {
+		html_end_box();
+		form_end();
+	}
+}


### PR DESCRIPTION
## Summary
- add shared action-form wrapper helpers in `ui_helpers.php`
- route `add_tree` and `add_branch` form wrappers through shared begin/end helpers
- preserve behavior while reducing duplicated conditional-header and form wrapper scaffolding

## Tests
- `php -l quicktree.php`
- `php -l ui_helpers.php`
- `php -l tests/test_form_wrapper.php`
- `php tests/test_form_wrapper.php`

Closes #9
